### PR TITLE
Fix builds that need CUDA libraries 

### DIFF
--- a/bazel_ros2_rules/ros2/defs.bzl
+++ b/bazel_ros2_rules/ros2/defs.bzl
@@ -127,6 +127,8 @@ def base_ros2_repository(repo_ctx, workspaces):
     cmd = ["./run.bash", str(path_to_generate_build_file_tool)]
     for path, path_in_sandbox in workspaces.items():
         cmd.extend(["-s", path + ":" + path_in_sandbox])
+    if repo_ctx.attr.allow_system_local:
+        cmd.extend(["--allow-system-local"])
     if repo_ctx.attr.jobs > 0:
         cmd.extend(["-j", repr(repo_ctx.attr.jobs)])
     cmd.extend(["-d", "distro_metadata.json", repo_ctx.name])
@@ -167,6 +169,11 @@ def base_ros2_repository_attrs():
         "exclude_packages": attr.string_list(
             doc = "Optional set of packages to exclude, " +
                   "with precedence over included packages. Defaults to none.",
+        ),
+        "allow_system_local": attr.bool(
+            doc = "Whether to allow linking libraries under /usr/local " +
+                  "or not. Defaults to False.",
+            default = False,
         ),
         "jobs": attr.int(
             doc = "Number of CMake jobs to use during package " +

--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/system.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/system.py
@@ -72,7 +72,7 @@ def is_system_library(library_path):
     """
     library_path = os.path.realpath(library_path)
     return any(
-        library_path.startswith(path)
+        library_path.startswith(os.path.realpath(path))
         for path in system_link_dirs() + system_shared_lib_dirs())
 
 


### PR DESCRIPTION
This patch does two things:

- It allows system library checks to see through symbolic links (as those used by the `/etc/alternatives` machinery)
- It allows the user to bypass safeguards for `/usr/local` libraries in `bazel_ros2_rules.

In combination, these two allow `bazel` to scrape ROS 2 packages that link to CUDA alternatives under `/usr/local`.