### PR TITLE
Handle Python packages with multiple top levels

### DIFF
--- a/bazel_ros2_rules/ros2/defs.bzl
+++ b/bazel_ros2_rules/ros2/defs.bzl
@@ -127,6 +127,8 @@ def base_ros2_repository(repo_ctx, workspaces):
     cmd = ["./run.bash", str(path_to_generate_build_file_tool)]
     for path, path_in_sandbox in workspaces.items():
         cmd.extend(["-s", path + ":" + path_in_sandbox])
+    if repo_ctx.attr.allow_system_local:
+        cmd.extend(["--allow-system-local"])
     if repo_ctx.attr.jobs > 0:
         cmd.extend(["-j", repr(repo_ctx.attr.jobs)])
     cmd.extend(["-d", "distro_metadata.json", repo_ctx.name])
@@ -167,6 +169,11 @@ def base_ros2_repository_attrs():
         "exclude_packages": attr.string_list(
             doc = "Optional set of packages to exclude, " +
                   "with precedence over included packages. Defaults to none.",
+        ),
+        "allow_system_local": attr.bool(
+            doc = "Whether to allow linking libraries under /usr/local " +
+                  "or not. Defaults to False.",
+            default = False,
         ),
         "jobs": attr.int(
             doc = "Number of CMake jobs to use during package " +

--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/ament_python.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/ament_python.py
@@ -1,6 +1,7 @@
 import glob
 from importlib.metadata import distribution
 from importlib.metadata import PackageNotFoundError
+import os.path
 import sysconfig
 
 from ros2bzl.scraping.properties import PyProperties

--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/ament_python.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/ament_python.py
@@ -22,8 +22,8 @@ def collect_ament_python_package_properties(name, metadata):
     egg_path, top_levels = find_python_package(name)
     properties = PyProperties()
     properties.python_eggs = tuple([egg_path])
-    properties.python_packages = tuple(map(os.path.isdir, top_levels))
-    properties.python_modules = tuple(map(os.path.isfile, top_levels))
+    properties.python_packages = tuple(filter(os.path.isdir, top_levels))
+    properties.python_modules = tuple(filter(os.path.isfile, top_levels))
 
     cc_libraries = []
     for top_level in properties.python_packages:

--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/ament_python.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/ament_python.py
@@ -22,7 +22,7 @@ def collect_ament_python_package_properties(name, metadata):
     egg_path, top_levels = find_python_package(name)
     properties = PyProperties()
     properties.python_eggs = tuple([egg_path])
-    properties.python_packages = tuple(map(os.path.isdirectory, top_levels))
+    properties.python_packages = tuple(map(os.path.isdir, top_levels))
     properties.python_modules = tuple(map(os.path.isfile, top_levels))
 
     cc_libraries = []

--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/ament_python.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/ament_python.py
@@ -23,7 +23,8 @@ def collect_ament_python_package_properties(name, metadata):
     properties = PyProperties()
     properties.python_eggs = tuple([egg_path])
     properties.python_packages = tuple(filter(os.path.isdir, top_levels))
-    properties.python_modules = tuple(filter(os.path.isfile, top_levels))
+    properties.python_modules = tuple([
+        top + ".py" for top in top_levels if os.path.isfile(top + ".py")])
 
     cc_libraries = []
     for top_level in properties.python_packages:

--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/properties.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/properties.py
@@ -47,11 +47,14 @@ class PyProperties:
         'cc_extensions',
         'cc_libraries',
         'python_packages',
+        'python_modules',
     )
 
     cc_extensions: Tuple[str]
     cc_libraries: Tuple[str]
-    python_packages: Tuple[Tuple[str, str]]
+    python_eggs: Tuple[str]
+    python_packages: Tuple[str]
+    python_modules: Tuple[str]
 
     def __init__(self, **kwargs):
         _init_helper(self, kwargs)

--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/properties.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/properties.py
@@ -46,6 +46,7 @@ class PyProperties:
     __slots__ = (
         'cc_extensions',
         'cc_libraries',
+        'python_eggs',
         'python_packages',
         'python_modules',
     )

--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/system.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/system.py
@@ -72,7 +72,7 @@ def is_system_library(library_path):
     """
     library_path = os.path.realpath(library_path)
     return any(
-        library_path.startswith(path)
+        library_path.startswith(os.path.realpath(path))
         for path in system_link_dirs() + system_shared_lib_dirs())
 
 

--- a/bazel_ros2_rules/ros2/resources/ros2bzl/templates.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/templates.py
@@ -150,15 +150,16 @@ def configure_package_py_library(
     name, metadata, properties, dependencies, sandbox
 ):
     target_name = py_name(name, metadata)
-    eggs = [sandbox(egg_path) for egg_path, _ in properties.python_packages]
-    tops = [
-        sandbox(top_level) for _, top_level in properties.python_packages]
+    eggs = [sandbox(egg_path) for egg_path in properties.python_eggs]
+    tops = [sandbox(top_level) for top_level in properties.python_packages]
+    extras = [sandbox(path) for path in properties.python_modules]
     imports = [os.path.dirname(egg) for egg in eggs]
 
     template = 'templates/package_py_library.bazel.tpl'
     config = {
         'name': target_name,
         'tops': tops,
+        'extras': extras,
         'eggs': eggs,
         'imports': imports
     }

--- a/bazel_ros2_rules/ros2/resources/templates/package_py_library.bazel.tpl
+++ b/bazel_ros2_rules/ros2/resources/templates/package_py_library.bazel.tpl
@@ -1,6 +1,6 @@
 py_library(
     name = @name@,
-    srcs = glob(["{}/**/*.py".format(x) for x in @tops@]),
+    srcs = glob(["{}/**/*.py".format(x) for x in @tops@]) + @extras@,
     data = glob(
        include=[
          "{}/**/*.*".format(x) for x in @tops@


### PR DESCRIPTION
Build on top of #1. This patch handles Python packages with multiple top levels (directories and/or files), such as `launch_testing_ros`.